### PR TITLE
Expose interpolators on initialization

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -69,7 +69,8 @@ export default class Carousel extends Component {
         vertical: PropTypes.bool,
         onBeforeSnapToItem: PropTypes.func,
         onSnapToItem: PropTypes.func,
-        onActiveItemChange: PropTypes.func
+        onActiveItemChange: PropTypes.func,
+        onInterpolatorInitialization: PropTypes.func
     };
 
     static defaultProps = {
@@ -567,7 +568,7 @@ export default class Carousel extends Component {
     }
 
     _initPositionsAndInterpolators (props = this.props) {
-        const { data, itemWidth, itemHeight, activeSlideProgressiveOffset, scrollInterpolator, vertical } = props;
+        const { data, itemWidth, itemHeight, activeSlideProgressiveOffset, scrollInterpolator, vertical, onInterpolatorInitialization } = props;
         const adjustedItemWidth = itemWidth - activeSlideProgressiveOffset;
         const sizeRef = vertical ? itemHeight : adjustedItemWidth;
 
@@ -615,7 +616,11 @@ export default class Carousel extends Component {
             interpolators.push(animatedValue);
         });
 
-        this.setState({ interpolators });
+        this.setState({ interpolators }, () => {
+            if (onInterpolatorInitialization) {
+                onInterpolatorInitialization(interpolators);
+            }
+        });
     }
 
     _getSlideAnimation (index, toValue) {

--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -345,10 +345,8 @@ export default class Carousel extends Component {
     }
 
     _shouldAnimateSlides (props = this.props) {
-        const { inactiveSlideOpacity, inactiveSlideScale, scrollInterpolator, slideInterpolatedStyle } = props;
-        return inactiveSlideOpacity < 1 ||
-            inactiveSlideScale < 1 ||
-            !!scrollInterpolator ||
+        const { scrollInterpolator, slideInterpolatedStyle } = props;
+        return !!scrollInterpolator ||
             !!slideInterpolatedStyle ||
             this._shouldUseShiftLayout() ||
             this._shouldUseStackLayout() ||


### PR DESCRIPTION
@briandeweese Implements a callback function to grab all carousel animation values after they've been initialized (rather than grabbing them individually from `renderItem`). There's a cool application for this in the upcoming welcome animation!